### PR TITLE
Add artifact build workflow and cross-platform build/runtime fixes

### DIFF
--- a/.github/workflows/artifact-build.yml
+++ b/.github/workflows/artifact-build.yml
@@ -1,0 +1,67 @@
+name: Artifact Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main, master ]
+  push:
+    branches: [ main, master ]
+
+jobs:
+  build-artifacts:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: windows
+            binary: DeepSeekChat.exe
+          - os: ubuntu-latest
+            target: linux
+            binary: DeepSeekChat
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build app + updater artifacts
+        run: python build.py --fresh
+
+      - name: Verify expected binary exists
+        shell: bash
+        run: |
+          if [ ! -f "built/${{ matrix.binary }}" ]; then
+            echo "Expected built/${{ matrix.binary }} not found"
+            ls -la built || true
+            exit 1
+          fi
+
+      - name: Verify updater binary exists
+        shell: bash
+        run: |
+          if [ "${{ matrix.target }}" = "windows" ]; then
+            test -f built/auto-updater.exe
+          else
+            test -f built/auto-updater
+          fi
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: DeepSeekChat-${{ matrix.target }}
+          path: built/
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 9

--- a/README.md
+++ b/README.md
@@ -33,11 +33,26 @@ A cozy desktop wrapper for DeepSeek Chat — smoother, prettier, and nice to use
 ## Installation
 
 1. Grab the latest release from the [Releases page](https://github.com/notlousybook/DeepSeek-Desktop/releases)
-2. Download `DeepSeekChat-windows.zip`
+2. Download the package for your OS (`DeepSeekChat-windows.zip` or Linux build artifact)
 3. Extract it somewhere nice
-4. Run `DeepSeekChat.exe`
+4. Run the app binary (`DeepSeekChat.exe` on Windows, `DeepSeekChat` on Linux)
 
 The app will keep itself updated automatically — you'll get a friendly notification when there's something new :3
+
+### Linux dependencies
+
+If the app opens but shows errors (or no window), install WebKit/GTK runtime packages:
+
+```bash
+# Debian/Ubuntu
+sudo apt install libgtk-3-0 libwebkit2gtk-4.1-0 xdg-utils policykit-1
+
+# Fedora
+sudo dnf install gtk3 webkit2gtk4.1 xdg-utils polkit
+
+# Arch
+sudo pacman -S gtk3 webkit2gtk xdg-utils polkit
+```
 
 ---
 
@@ -108,7 +123,8 @@ By default, it'll just follow your Windows theme.
 - [x] Dark titlebar support
 - [x] Keyboard shortcuts
 - [ ] Custom themes (pick your own colors!)
-- [ ] macOS and Linux builds
+- [ ] macOS build
+- [x] Linux support improvements
 - [ ] System tray integration
 
 ---

--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ If the app opens but shows errors (or no window), install WebKit/GTK runtime pac
 
 ```bash
 # Debian/Ubuntu
-sudo apt install libgtk-3-0 libwebkit2gtk-4.1-0 xdg-utils policykit-1
+sudo apt install --no-install-recommends libgtk-3-0 libwebkit2gtk-4.1-0 xdg-utils
 
 # Fedora
-sudo dnf install gtk3 webkit2gtk4.1 xdg-utils polkit
+sudo dnf install gtk3 webkit2gtk4.1 xdg-utils
 
 # Arch
-sudo pacman -S gtk3 webkit2gtk xdg-utils polkit
+sudo pacman -S gtk3 webkit2gtk xdg-utils
 ```
+> Optional: install PolicyKit (`policykit-1` / `polkit`) only if your distro or updater flow needs elevation prompts.
+
 
 ---
 

--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import argparse
 import re  # For parsing version from workflow file
+import platform
 
 def get_version_from_workflow():
     """Extract version from GitHub workflow file"""
@@ -36,7 +37,9 @@ def build_app(fresh=False):
     if not os.path.exists("injection"):
         print("Error: injection directory not found!")
         return
-    if not os.path.exists("deepseek.ico"):
+
+    icon_exists = os.path.exists("deepseek.ico")
+    if platform.system() == "Windows" and not icon_exists:
         print("Error: deepseek.ico icon not found!")
         return
     
@@ -53,21 +56,22 @@ def build_app(fresh=False):
     os.makedirs(temp_dir, exist_ok=True)
     os.makedirs(dist_dir, exist_ok=True)
     
-    # Get absolute path to icon
-    icon_path = os.path.abspath("deepseek.ico")
-    
-    # PyInstaller command with absolute icon path
+    # Get absolute path to icon when available
+    icon_path = os.path.abspath("deepseek.ico") if icon_exists else None
+
+    # PyInstaller command
     cmd = [
         "pyinstaller",
         "--onefile",
-        "--windowed",  # Create Windows GUI app (no console)
-        f"--icon={icon_path}",
+        "--windowed",
         f"--distpath={dist_dir}",
         f"--workpath={temp_dir}",
         f"--specpath={temp_dir}",
         "-n", "DeepSeekChat",
         "main.py"
     ]
+    if icon_path:
+        cmd.insert(3, f"--icon={icon_path}")
     
     # Run PyInstaller
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -90,17 +94,19 @@ def build_app(fresh=False):
     # Define resources to copy to built directory
     resources_to_copy = [
         ("injection", "injection"),  # (source, destination)
-        ("deepseek.ico", "deepseek.ico")
     ]
+    if icon_exists:
+        resources_to_copy.append(("deepseek.ico", "deepseek.ico"))
 
     # --- Auto-Updater Logic ---
     updater_script_dir = os.path.join(os.path.dirname(__file__), "utils")
-    generated_exe_path = os.path.join(updater_script_dir, "auto-updater.exe")
-    final_exe_path = os.path.join(dist_dir, "auto-updater.exe")
+    updater_binary_name = "auto-updater.exe" if platform.system() == "Windows" else "auto-updater"
+    generated_exe_path = os.path.join(updater_script_dir, updater_binary_name)
+    final_exe_path = os.path.join(dist_dir, updater_binary_name)
 
-    # Check if auto-updater.exe already exists in utils folder or if --fresh flag is used
+    # Check if updater binary already exists in utils folder or if --fresh flag is used
     if fresh or not os.path.exists(generated_exe_path):
-        print(f"{'--fresh flag used. Regenerating' if fresh else 'auto-updater.exe not found in utils/.'} Generating auto-updater.exe now...")
+        print(f"{'--fresh flag used. Regenerating' if fresh else f'{updater_binary_name} not found in utils/.'} Generating {updater_binary_name} now...")
         build_updater_script = os.path.join(updater_script_dir, "build-updater.py")
         
         if not os.path.exists(build_updater_script):
@@ -112,26 +118,26 @@ def build_app(fresh=False):
         
         result = subprocess.run([sys.executable, build_updater_script], capture_output=True, text=True)
         if result.returncode != 0:
-            print("Failed to build auto-updater.exe!")
+            print(f"Failed to build {updater_binary_name}!")
             print("Error:", result.stderr)
             return # Or handle error
         
-        print("auto-updater.exe generated successfully!")
+        print(f"{updater_binary_name} generated successfully!")
         # The build-updater.py script now places the exe directly in the utils directory
         # We need to copy it to the final build directory
         if not os.path.exists(generated_exe_path):
-            print("Critical Error: auto-updater.exe could not be found in utils directory after build process.")
+            print(f"Critical Error: {updater_binary_name} could not be found in utils directory after build process.")
             return
 
-    # Copy the generated auto-updater.exe from utils to the dist_dir
+    # Copy the generated updater binary from utils to dist_dir
     if os.path.exists(generated_exe_path):
         if not os.path.exists(final_exe_path):
             shutil.copy(generated_exe_path, final_exe_path)
-            print(f"Copied auto-updater.exe from utils to {dist_dir}")
+            print(f"Copied {updater_binary_name} from utils to {dist_dir}")
         else:
-            print(f"auto-updater.exe already exists at {final_exe_path}")
+            print(f"{updater_binary_name} already exists at {final_exe_path}")
     else:
-        print("Warning: auto-updater.exe was not found in utils directory.")
+        print(f"Warning: {updater_binary_name} was not found in utils directory.")
     
     # Copy resources
     for src, dest in resources_to_copy:
@@ -145,15 +151,22 @@ def build_app(fresh=False):
     
     print("\nBuild complete! Executable and resources are in ./built/ directory")
     
-    # Open the output directory in Explorer
-    os.startfile(os.path.abspath(dist_dir))
+    # Open output directory on supported platforms
+    dist_abs = os.path.abspath(dist_dir)
+    if platform.system() == "Windows":
+        os.startfile(dist_abs)
+    elif platform.system() == "Darwin":
+        subprocess.Popen(["open", dist_abs])
+    else:
+        if shutil.which("xdg-open"):
+            subprocess.Popen(["xdg-open", dist_abs])
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Build the DeepSeek Desktop application and its updater.")
     parser.add_argument(
         "--fresh",
         action="store_true",
-        help="Force regeneration of the auto-updater.exe."
+        help="Force regeneration of the updater binary."
     )
     args = parser.parse_args()
     build_app(fresh=args.fresh)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,8 @@ import os
 import argparse
 import sys
 import platform
+import shutil
+import ctypes.util
 import datetime
 import base64
 import io
@@ -75,6 +77,54 @@ def _log(msg: str):
     
     # Always print to console for visibility with safe printing
     safe_print(msg)
+
+def _linux_dependency_help_messages():
+    """Detect Linux runtime dependencies and return user-friendly install guidance."""
+    if platform.system() != "Linux":
+        return []
+
+    messages = []
+    missing_commands = []
+    for cmd in ["xdg-open", "pkexec"]:
+        if shutil.which(cmd) is None:
+            missing_commands.append(cmd)
+
+    if missing_commands:
+        messages.append(
+            "Missing helper commands: "
+            + ", ".join(missing_commands)
+            + ". Install desktop integration tools (examples below)."
+        )
+
+    webkit_lib = ctypes.util.find_library("webkit2gtk-4.1") or ctypes.util.find_library("webkit2gtk-4.0")
+    gtk_lib = ctypes.util.find_library("gtk-3")
+    if not webkit_lib or not gtk_lib:
+        messages.append(
+            "WebView runtime libraries not detected (GTK3/WebKit2GTK). "
+            "The app window may fail to open until these are installed."
+        )
+
+    return messages
+
+def log_linux_setup_guidance():
+    """Log Linux dependency checks and distro-specific installation hints."""
+    if platform.system() != "Linux":
+        return
+
+    messages = _linux_dependency_help_messages()
+    if not messages:
+        _log("Linux dependency check: required runtime components look available.")
+        return
+
+    _log("Linux dependency check found missing components:")
+    for msg in messages:
+        _log(f"  - {msg}")
+
+    _log("Install guidance:")
+    _log("  - Debian/Ubuntu: sudo apt install libgtk-3-0 libwebkit2gtk-4.1-0 xdg-utils policykit-1")
+    _log("  - Fedora: sudo dnf install gtk3 webkit2gtk4.1 xdg-utils polkit")
+    _log("  - Arch: sudo pacman -S gtk3 webkit2gtk xdg-utils polkit")
+    _log("After installing dependencies, restart DeepSeek Desktop.")
 
 # Windows-specific imports for dark titlebar
 if platform.system() == "Windows":
@@ -568,7 +618,7 @@ def launch_auto_updater():
         ]
         
         # Define possible updater names
-        executable_names = ['auto-updater.exe']
+        executable_names = ['auto-updater.exe'] if platform.system() == "Windows" else ['auto-updater']
         script_names = ['auto-updater.py', 'auto_update.py']
         
         # Check for executable first
@@ -597,18 +647,17 @@ def launch_auto_updater():
                 env = os.environ.copy()
                 env['PYTHONIOENCODING'] = 'utf-8'
                 env['PYTHONLEGACYWINDOWSSTDIO'] = '0'  # Ensure UTF-8 stdio on Windows
+                popen_kwargs = {"env": env}
+                if platform.system() == "Windows":
+                    popen_kwargs["creationflags"] = subprocess.CREATE_NEW_CONSOLE
                 
                 if updater_type == 'executable':
                     # Launch executable with UTF-8 environment
-                    subprocess.Popen([updater_path], 
-                                   creationflags=subprocess.CREATE_NEW_CONSOLE,
-                                   env=env)
+                    subprocess.Popen([updater_path], **popen_kwargs)
                     _log(f"Launched auto-updater executable: {updater_path}")
                 else:  # script
                     # Launch Python script with appropriate flags and UTF-8 environment
-                    subprocess.Popen([sys.executable, updater_path, '--auto', '--debug'], 
-                                   creationflags=subprocess.CREATE_NEW_CONSOLE,
-                                   env=env)
+                    subprocess.Popen([sys.executable, updater_path, '--auto', '--debug'], **popen_kwargs)
                     _log(f"Launched auto-updater script: {updater_path}")
             except Exception as launch_error:
                 error_msg = f"Failed to launch auto-updater: {launch_error}"
@@ -717,6 +766,8 @@ def main():
     
     global VERBOSE_LOGS
     VERBOSE_LOGS = not release_mode
+
+    log_linux_setup_guidance()
     
     app = DeepSeekApp(release_mode=release_mode)
     app.run()

--- a/main.py
+++ b/main.py
@@ -85,7 +85,7 @@ def _linux_dependency_help_messages():
 
     messages = []
     missing_commands = []
-    for cmd in ["xdg-open", "pkexec"]:
+    for cmd in ["xdg-open"]:
         if shutil.which(cmd) is None:
             missing_commands.append(cmd)
 
@@ -121,9 +121,10 @@ def log_linux_setup_guidance():
         _log(f"  - {msg}")
 
     _log("Install guidance:")
-    _log("  - Debian/Ubuntu: sudo apt install libgtk-3-0 libwebkit2gtk-4.1-0 xdg-utils policykit-1")
-    _log("  - Fedora: sudo dnf install gtk3 webkit2gtk4.1 xdg-utils polkit")
-    _log("  - Arch: sudo pacman -S gtk3 webkit2gtk xdg-utils polkit")
+    _log("  - Debian/Ubuntu: sudo apt install --no-install-recommends libgtk-3-0 libwebkit2gtk-4.1-0 xdg-utils")
+    _log("  - Fedora: sudo dnf install gtk3 webkit2gtk4.1 xdg-utils")
+    _log("  - Arch: sudo pacman -S gtk3 webkit2gtk xdg-utils")
+    _log("Optional: install policykit only if your distro/updater flow needs elevated auth prompts.")
     _log("After installing dependencies, restart DeepSeek Desktop.")
 
 # Windows-specific imports for dark titlebar

--- a/utils/auto_update.py
+++ b/utils/auto_update.py
@@ -49,7 +49,7 @@ def safe_print(text: str):
         print(f"[Encoding Error: {str(e)}]")
 
 # --- Configuration ---
-APP_NAME = "DeepSeekChat.exe"
+APP_NAME = "DeepSeekChat.exe" if platform.system() == "Windows" else "DeepSeekChat"
 REPO_URL = "https://api.github.com/repos/LousyBook94/DeepSeek-Desktop/releases/latest"
 VERSION_FILE = "version.txt"
 TEMP_DIR = os.path.join(tempfile.gettempdir(), "DeepSeekUpdate")
@@ -620,36 +620,44 @@ def main():
 
     # Check if application is running and close it if needed (only when update is needed)
     try:
-        subprocess.check_output(
-            f'tasklist /FI "IMAGENAME eq {APP_NAME}" /FO CSV | find "{APP_NAME}"',
-            shell=True,
-            stderr=subprocess.DEVNULL
-        )
-        logger.info(f"{APP_NAME} is running. Attempting to close...")
-        subprocess.run(
-            f'taskkill /F /IM "{APP_NAME}"',
-            shell=True,
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL
-        )
+        if platform.system() == "Windows":
+            subprocess.check_output(
+                f'tasklist /FI "IMAGENAME eq {APP_NAME}" /FO CSV | find "{APP_NAME}"',
+                shell=True,
+                stderr=subprocess.DEVNULL
+            )
+            logger.info(f"{APP_NAME} is running. Attempting to close...")
+            subprocess.run(
+                f'taskkill /F /IM "{APP_NAME}"',
+                shell=True,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL
+            )
+        else:
+            subprocess.check_output(["pgrep", "-f", APP_NAME], stderr=subprocess.DEVNULL)
+            logger.info(f"{APP_NAME} is running. Attempting to close...")
+            subprocess.run(["pkill", "-f", APP_NAME], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         time.sleep(3)
         logger.info(f"{APP_NAME} closed.")
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         logger.info(f"{APP_NAME} is not running.")
     
     console.print(Panel(f"[bold yellow]Update available: {current_version} -> {latest_version}[/bold yellow]", border_style="yellow"))
 
-    # Find Windows asset
+    # Find platform-appropriate asset
     asset_to_download = None
+    target_markers = ["windows.zip"] if platform.system() == "Windows" else ["linux.zip", "linux.tar.gz", "linux"]
     if release_info and "assets" in release_info:
         for asset in release_info["assets"]:
-            if "windows.zip" in asset["name"].lower():
+            asset_name = asset["name"].lower()
+            if any(marker in asset_name for marker in target_markers):
                 asset_to_download = asset
                 break
-    
+
     if not asset_to_download:
-        console.print(Panel("[bold red]Error: Windows release asset not found.[/bold red]", border_style="red"))
+        wanted = "Windows" if platform.system() == "Windows" else "Linux"
+        console.print(Panel(f"[bold red]Error: {wanted} release asset not found.[/bold red]", border_style="red"))
         if auto_mode:
             sys.exit(1)
         return

--- a/utils/build-updater.py
+++ b/utils/build-updater.py
@@ -3,6 +3,8 @@ import sys
 import shutil
 import subprocess
 import argparse
+import platform
+
 
 def build_updater(script_dir, output_dir):
     """
@@ -10,6 +12,7 @@ def build_updater(script_dir, output_dir):
     """
     auto_update_script = os.path.join(script_dir, "auto_update.py")
     icon_path = os.path.join(os.path.dirname(script_dir), "deepseek.ico")
+    binary_name = "auto-updater.exe" if platform.system() == "Windows" else "auto-updater"
     if not os.path.exists(auto_update_script):
         print(f"Error: auto_update.py not found in {script_dir}")
         return False
@@ -17,24 +20,23 @@ def build_updater(script_dir, output_dir):
     # Ensure output directory exists
     os.makedirs(output_dir, exist_ok=True)
 
-    # PyInstaller command with UTF-8 encoding support
     pyinstaller_cmd = [
         "pyinstaller",
         "--onefile",
-        "--name", "auto-updater",
-        f"--icon={icon_path}",
+        "--name", binary_name,
         "--distpath", output_dir,
         "--workpath", os.path.join(script_dir, "build_updater_temp"),
         "--specpath", os.path.join(script_dir, "build_updater_temp"),
-        # Ensure UTF-8 encoding support is included
         "--hidden-import", "encodings.utf_8",
         "--hidden-import", "encodings.ascii",
         "--hidden-import", "encodings.cp1252",
         "--hidden-import", "codecs",
-        auto_update_script
+        auto_update_script,
     ]
 
-    print("Building auto-updater.exe...")
+    print(f"Building {binary_name}...")
+    if os.path.exists(icon_path):
+        pyinstaller_cmd.extend(["--icon", icon_path])
     print(f"Running: {' '.join(pyinstaller_cmd)}")
 
     try:
@@ -55,39 +57,41 @@ def build_updater(script_dir, output_dir):
         print("You can install it using: pip install pyinstaller")
         return False
     finally:
-        # Clean up temporary build artifacts
         temp_build_dir = os.path.join(script_dir, "build_updater_temp")
         if os.path.exists(temp_build_dir):
             shutil.rmtree(temp_build_dir, ignore_errors=True)
             print("Cleaned up temporary build directory.")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Build the DeepSeek Desktop Auto-Updater.")
     parser.add_argument(
         "--output-dir",
         default=os.path.dirname(__file__),
-        help="Directory to save the built executable (default: same directory as build-updater.py)."
+        help="Directory to save the built executable (default: same directory as build-updater.py).",
     )
 
     args = parser.parse_args()
 
-    # Determine paths
     script_dir = os.path.dirname(os.path.abspath(__file__))
     output_dir = os.path.abspath(args.output_dir)
-    
 
-    # Build the updater
     if build_updater(script_dir, output_dir):
-        exe_path = os.path.join(output_dir, "auto-updater.exe")
-        print(f"\nSuccess! auto-updater.exe created at: {exe_path}")
-        
-        # Open the output directory
+        updater_name = "auto-updater.exe" if platform.system() == "Windows" else "auto-updater"
+        updater_path = os.path.join(output_dir, updater_name)
+        print(f"\nSuccess! {updater_name} created at: {updater_path}")
+
         print(f"Opening output directory: {output_dir}")
         if sys.platform == "win32":
             os.startfile(output_dir)
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", output_dir])
+        elif shutil.which("xdg-open"):
+            subprocess.Popen(["xdg-open", output_dir])
     else:
         print("\nBuild failed. Please check the errors above.")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation

- Provide an automated CI job to produce release artifacts for Windows and Linux and improve cross-platform support during local builds and runtime.
- Make the build and updater tooling aware of non-Windows platforms so the app and auto-updater behave correctly on Linux/macOS.
- Improve user guidance for missing Linux runtime dependencies and make opening build outputs and updater names platform-appropriate.

### Description

- Add a new GitHub Actions workflow `/.github/workflows/artifact-build.yml` to build and upload artifacts for `windows` and `linux` via `pyinstaller` and `build.py`.
- Update `build.py` to detect platform via `platform.system()`, make the icon optional on non-Windows, choose the updater binary name per-OS, insert the icon flag only when present, create `version.txt`, and open the `built/` folder in a cross-platform way.
- Enhance `main.py` with Linux runtime dependency checks and logging (`_linux_dependency_help_messages` and `log_linux_setup_guidance`), adjust updater discovery/launch to prefer platform-appropriate updater names, and use `creationflags` only on Windows when launching subprocesses.
- Make `utils/auto_update.py` platform-aware by setting `APP_NAME` per-OS, using `tasklist/taskkill` on Windows and `pgrep/pkill` on Unix, selecting the correct release asset markers for Windows vs Linux, and improving user-facing messages.
- Update `utils/build-updater.py` to pick a platform-specific binary name, optionally include the icon, and open the output directory in a cross-platform manner.
- Documentation updates in `README.md` to clarify platform download/run instructions and to add Linux dependency install snippets and status updates for macOS/Linux support.

### Testing

- No automated unit tests were added in this change; CI will perform artifact builds using the added `artifact-build` workflow on `push`, `pull_request`, or manual `workflow_dispatch` triggers.
- Manual/functional expectations: the build scripts were updated to produce `built/` artifacts with `version.txt` and a platform-named updater binary; runtime dependency guidance is logged on Linux when dependencies are missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58ca623a88329aee25e9460c7b017)

## Summary by Sourcery

Add cross-platform build, updater, and runtime support and introduce a CI workflow to produce release artifacts for Windows and Linux.

New Features:
- Introduce a GitHub Actions workflow to build and upload Windows and Linux artifacts via the existing build pipeline.
- Add Linux runtime dependency detection and user-facing setup guidance logged at application startup.

Enhancements:
- Make the main app, build script, and updater tooling platform-aware, including OS-specific binary naming, subprocess flags, and process management.
- Allow builds to proceed without an icon on non-Windows platforms and open build output folders in a cross-platform way.
- Improve updater asset selection and error messaging based on the current operating system.

CI:
- Add an artifact-build GitHub Actions workflow to build, validate, and upload DeepSeekChat artifacts for Windows and Linux on pushes, pull requests, and manual runs.

Documentation:
- Update README with cross-platform install/run instructions and Linux dependency installation examples, and refresh the platform support status.